### PR TITLE
Fixed License and added it to every file.

### DIFF
--- a/pytweet/attachments.py
+++ b/pytweet/attachments.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/auth.py
+++ b/pytweet/auth.py
@@ -1,3 +1,26 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021 TheFarGG & TheGenocides
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
 from requests_oauthlib import OAuth1, OAuth1Session
 
 

--- a/pytweet/client.py
+++ b/pytweet/client.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/enums.py
+++ b/pytweet/enums.py
@@ -1,3 +1,27 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021 TheFarGG & TheGenocides
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
 from enum import Enum
 
 class RelationsTypeEnum(Enum):

--- a/pytweet/errors.py
+++ b/pytweet/errors.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/http.py
+++ b/pytweet/http.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/metrics.py
+++ b/pytweet/metrics.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/relations.py
+++ b/pytweet/relations.py
@@ -1,3 +1,28 @@
+"""
+
+The MIT License (MIT)
+
+Copyright (c) 2021 TheFarGG & TheGenocides
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
 from typing import Dict, Any
 from .enums import RelationsTypeEnum
 

--- a/pytweet/tweet.py
+++ b/pytweet/tweet.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/user.py
+++ b/pytweet/user.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 

--- a/pytweet/utils.py
+++ b/pytweet/utils.py
@@ -1,5 +1,5 @@
 """
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2021 TheFarGG & TheGenocides
 


### PR DESCRIPTION
In the license file it said `the MIT LICENSE (mit)` and in code files said `MIT License`and some codefiles didnt have the license.

This PR fixes it by adding License to every file and replacing `MIT License` with `the MIT LICENSE (mit)` to keep it the same as in license file.
