### PR TITLE
Use `_total_bytes` var in `File.total_bytes`

### DIFF
--- a/pytweet/attachments.py
+++ b/pytweet/attachments.py
@@ -75,7 +75,7 @@ class File:
         
         .. versionadded:: 1.3.5
         """
-        return os.path.getsize(self.path)
+        return self._total_bytes
 
     @property
     def media_category(self) -> str:


### PR DESCRIPTION
## Description

File.total_bytes uses `os.path.getsize` but since the `_total_bytes` is the same, so i made it return that instead of calling the function again.

## How Has This Been Tested?
No need for tests.

## Checklist

<!---- Put an x inside [ ] to check it, like so: [x] ----->

- [x] I have read the CONTRIBUTING guide of this project.
- [ ] This PR fixes an issue.
- [ ] This PR has major changes (e.g. new classes, params renamed, etc)
- [ ] This PR **is not** about the module's code (e.g. documentation, README, etc)
