### PR TITLE
Remove useless requirement of `yarl`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 requests_oauthlib 
 python-dateutil
-yarl


### PR DESCRIPTION
## Description
Removes useless requirement `yarl`


## How Has This Been Tested?
Well the module was not used anywhere in the code so it doesn't need to be tested.
## Checklist

<!---- Put an x inside [ ] to check it, like so: [x] ----->

- [x] I have read the CONTRIBUTING guide of this project.
- [ ] This PR fixes an issue.
- [ ] This PR has major changes (e.g. new classes, params renamed, etc)
- [ ] This PR **is not** about the module's code (e.g. documentation, README, etc)
