### PR TITLE
Add flask to requirements.txt - w3bhook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 requests_oauthlib 
 python-dateutil
+flask


### PR DESCRIPTION
## Description

Fixes a bug report in PyTweet discord by UnsoughtConch, making a point that PyTweet uses flask, however it does not mention it in requirements.txt


## How Has This Been Tested?

Not tested (only a requirements.txt change)

## Checklist

- [x] I have read the CONTRIBUTING guide of this project.
- [x] This PR fixes an issue.
- [ ] This PR has major changes (e.g. new classes, params renamed, etc)
- [x] This PR **is not** about the module's code (e.g. documentation, README, etc)
